### PR TITLE
Require Django dep.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     url='https://github.com/philippbosch/django-sirtrevor/',
     author='Philipp Bosch',
     author_email='hello@pb.io',
-    install_requires=['markdown2', 'django-appconf'],
+    install_requires=['markdown2', 'django-appconf', 'django'],
     classifiers=[
         'Environment :: Web Environment',
         'Framework :: Django',


### PR DESCRIPTION
This wouldn't build on a fresh environment due to Django being required for the build.

```
pip install django-sirtrevor
  File "/vagrant/venv/build/django-sirtrevor/setup.py", line 3, in <module>
    from sirtrevor import __version__
  File "sirtrevor/__init__.py", line 2, in <module>
    from django.template.loader import render_to_string
ImportError: No module named django.template.loader
```
